### PR TITLE
Refactor into clean architecture with BLoC

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'quiz/data/repositories/question_repository_impl.dart';
+import 'quiz/domain/usecases/get_questions.dart';
+import 'quiz/presentation/bloc/quiz_bloc.dart';
+import 'quiz/presentation/pages/quiz_page.dart';
 
 void main() {
   runApp(const QuizApp());
-}
-
-class Question {
-  final String text;
-  final List<String> options;
-  final int answerIndex;
-
-  const Question({
-    required this.text,
-    required this.options,
-    required this.answerIndex,
-  });
 }
 
 class QuizApp extends StatelessWidget {
@@ -21,159 +14,15 @@ class QuizApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final repository = QuestionRepositoryImpl();
     return MaterialApp(
       title: 'Quiz App',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const QuizPage(),
-    );
-  }
-}
-
-class QuizPage extends StatefulWidget {
-  const QuizPage({super.key});
-
-  @override
-  State<QuizPage> createState() => _QuizPageState();
-}
-
-class _QuizPageState extends State<QuizPage> {
-  final List<Question> _questions = const [
-    Question(
-      text: 'What is the capital of France?',
-      options: ['Berlin', 'London', 'Paris', 'Rome'],
-      answerIndex: 2,
-    ),
-    Question(
-      text: 'Which planet is known as the Red Planet?',
-      options: ['Mars', 'Venus', 'Jupiter', 'Saturn'],
-      answerIndex: 0,
-    ),
-    Question(
-      text: 'Who wrote Hamlet?',
-      options: ['Charles Dickens', 'William Shakespeare', 'Mark Twain', 'Ernest Hemingway'],
-      answerIndex: 1,
-    ),
-    Question(
-      text: 'Which ocean is the largest?',
-      options: ['Atlantic', 'Pacific', 'Indian', 'Arctic'],
-      answerIndex: 1,
-    ),
-    Question(
-      text: 'What is the square root of 64?',
-      options: ['6', '7', '8', '9'],
-      answerIndex: 2,
-    ),
-  ];
-
-  int _currentIndex = 0;
-  int _score = 0;
-  int? _selectedIndex;
-  bool _answered = false;
-
-  void _selectOption(int index) {
-    if (_answered) return;
-
-    setState(() {
-      _selectedIndex = index;
-      _answered = true;
-      if (index == _questions[_currentIndex].answerIndex) {
-        _score++;
-      }
-    });
-  }
-
-  void _nextQuestion() {
-    setState(() {
-      _currentIndex++;
-      _selectedIndex = null;
-      _answered = false;
-    });
-  }
-
-  void _restartQuiz() {
-    setState(() {
-      _currentIndex = 0;
-      _score = 0;
-      _selectedIndex = null;
-      _answered = false;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_currentIndex >= _questions.length) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('Quiz Finished')),
-        body: Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                'Your score: $_score / ${_questions.length}',
-                style: const TextStyle(fontSize: 24),
-              ),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: _restartQuiz,
-                child: const Text('Restart Quiz'),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
-    final question = _questions[_currentIndex];
-
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Question ${_currentIndex + 1} / ${_questions.length}'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              question.text,
-              style: const TextStyle(fontSize: 20),
-            ),
-            const SizedBox(height: 20),
-            for (int i = 0; i < question.options.length; i++)
-              _buildOption(i, question.options[i]),
-            const SizedBox(height: 20),
-            if (_answered)
-              ElevatedButton(
-                onPressed: _currentIndex == _questions.length - 1
-                    ? () => setState(() => _currentIndex++)
-                    : _nextQuestion,
-                child: Text(
-                  _currentIndex == _questions.length - 1 ? 'Finish' : 'Next',
-                ),
-              )
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildOption(int index, String text) {
-    Color? color;
-    if (_answered) {
-      if (index == _questions[_currentIndex].answerIndex) {
-        color = Colors.green;
-      } else if (index == _selectedIndex) {
-        color = Colors.red;
-      }
-    }
-
-    return Card(
-      color: color,
-      child: ListTile(
-        title: Text(text),
-        onTap: () => _selectOption(index),
+      home: BlocProvider(
+        create: (_) => QuizBloc(getQuestions: GetQuestions(repository)),
+        child: const QuizPage(),
       ),
     );
   }

--- a/lib/quiz/data/repositories/question_repository_impl.dart
+++ b/lib/quiz/data/repositories/question_repository_impl.dart
@@ -1,0 +1,35 @@
+import '../../quiz/domain/entities/question.dart';
+import '../../quiz/domain/repositories/question_repository.dart';
+
+class QuestionRepositoryImpl implements QuestionRepository {
+  @override
+  List<Question> getQuestions() {
+    return const [
+      Question(
+        text: 'What is the capital of France?',
+        options: ['Berlin', 'London', 'Paris', 'Rome'],
+        answerIndex: 2,
+      ),
+      Question(
+        text: 'Which planet is known as the Red Planet?',
+        options: ['Mars', 'Venus', 'Jupiter', 'Saturn'],
+        answerIndex: 0,
+      ),
+      Question(
+        text: 'Who wrote Hamlet?',
+        options: ['Charles Dickens', 'William Shakespeare', 'Mark Twain', 'Ernest Hemingway'],
+        answerIndex: 1,
+      ),
+      Question(
+        text: 'Which ocean is the largest?',
+        options: ['Atlantic', 'Pacific', 'Indian', 'Arctic'],
+        answerIndex: 1,
+      ),
+      Question(
+        text: 'What is the square root of 64?',
+        options: ['6', '7', '8', '9'],
+        answerIndex: 2,
+      ),
+    ];
+  }
+}

--- a/lib/quiz/domain/entities/question.dart
+++ b/lib/quiz/domain/entities/question.dart
@@ -1,0 +1,11 @@
+class Question {
+  final String text;
+  final List<String> options;
+  final int answerIndex;
+
+  const Question({
+    required this.text,
+    required this.options,
+    required this.answerIndex,
+  });
+}

--- a/lib/quiz/domain/repositories/question_repository.dart
+++ b/lib/quiz/domain/repositories/question_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/question.dart';
+
+abstract class QuestionRepository {
+  List<Question> getQuestions();
+}

--- a/lib/quiz/domain/usecases/get_questions.dart
+++ b/lib/quiz/domain/usecases/get_questions.dart
@@ -1,0 +1,10 @@
+import '../entities/question.dart';
+import '../repositories/question_repository.dart';
+
+class GetQuestions {
+  final QuestionRepository repository;
+
+  const GetQuestions(this.repository);
+
+  List<Question> call() => repository.getQuestions();
+}

--- a/lib/quiz/presentation/bloc/quiz_bloc.dart
+++ b/lib/quiz/presentation/bloc/quiz_bloc.dart
@@ -1,0 +1,69 @@
+import 'package:bloc/bloc.dart';
+import '../../domain/entities/question.dart';
+import '../../domain/usecases/get_questions.dart';
+import 'quiz_event.dart';
+import 'quiz_state.dart';
+
+class QuizBloc extends Bloc<QuizEvent, QuizState> {
+  final GetQuestions getQuestions;
+  late final List<Question> _questions;
+  int _currentIndex = 0;
+  int _score = 0;
+  int? _selectedIndex;
+  bool _answered = false;
+
+  QuizBloc({required this.getQuestions}) : super(QuizInitial()) {
+    on<StartQuiz>(_onStartQuiz);
+    on<SelectOption>(_onSelectOption);
+    on<NextQuestion>(_onNextQuestion);
+    on<RestartQuiz>(_onRestartQuiz);
+  }
+
+  void _onStartQuiz(StartQuiz event, Emitter<QuizState> emit) {
+    _questions = getQuestions();
+    _currentIndex = 0;
+    _score = 0;
+    _selectedIndex = null;
+    _answered = false;
+    emit(QuizQuestion(
+      question: _questions[_currentIndex],
+      currentIndex: _currentIndex,
+      total: _questions.length,
+    ));
+  }
+
+  void _onSelectOption(SelectOption event, Emitter<QuizState> emit) {
+    if (_answered || _currentIndex >= _questions.length) return;
+    _selectedIndex = event.index;
+    _answered = true;
+    if (event.index == _questions[_currentIndex].answerIndex) {
+      _score++;
+    }
+    emit(QuizQuestion(
+      question: _questions[_currentIndex],
+      currentIndex: _currentIndex,
+      total: _questions.length,
+      selectedIndex: _selectedIndex,
+      answered: _answered,
+    ));
+  }
+
+  void _onNextQuestion(NextQuestion event, Emitter<QuizState> emit) {
+    if (_currentIndex >= _questions.length - 1) {
+      emit(QuizFinished(score: _score, total: _questions.length));
+      return;
+    }
+    _currentIndex++;
+    _selectedIndex = null;
+    _answered = false;
+    emit(QuizQuestion(
+      question: _questions[_currentIndex],
+      currentIndex: _currentIndex,
+      total: _questions.length,
+    ));
+  }
+
+  void _onRestartQuiz(RestartQuiz event, Emitter<QuizState> emit) {
+    add(StartQuiz());
+  }
+}

--- a/lib/quiz/presentation/bloc/quiz_event.dart
+++ b/lib/quiz/presentation/bloc/quiz_event.dart
@@ -1,0 +1,23 @@
+import 'package:equatable/equatable.dart';
+
+abstract class QuizEvent extends Equatable {
+  const QuizEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class StartQuiz extends QuizEvent {}
+
+class SelectOption extends QuizEvent {
+  final int index;
+
+  const SelectOption(this.index);
+
+  @override
+  List<Object?> get props => [index];
+}
+
+class NextQuestion extends QuizEvent {}
+
+class RestartQuiz extends QuizEvent {}

--- a/lib/quiz/presentation/bloc/quiz_state.dart
+++ b/lib/quiz/presentation/bloc/quiz_state.dart
@@ -1,0 +1,40 @@
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/question.dart';
+
+abstract class QuizState extends Equatable {
+  const QuizState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class QuizInitial extends QuizState {}
+
+class QuizQuestion extends QuizState {
+  final Question question;
+  final int currentIndex;
+  final int total;
+  final int? selectedIndex;
+  final bool answered;
+
+  const QuizQuestion({
+    required this.question,
+    required this.currentIndex,
+    required this.total,
+    this.selectedIndex,
+    this.answered = false,
+  });
+
+  @override
+  List<Object?> get props => [question, currentIndex, total, selectedIndex, answered];
+}
+
+class QuizFinished extends QuizState {
+  final int score;
+  final int total;
+
+  const QuizFinished({required this.score, required this.total});
+
+  @override
+  List<Object?> get props => [score, total];
+}

--- a/lib/quiz/presentation/pages/quiz_page.dart
+++ b/lib/quiz/presentation/pages/quiz_page.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../bloc/quiz_bloc.dart';
+import '../bloc/quiz_event.dart';
+import '../bloc/quiz_state.dart';
+import '../widgets/option_card.dart';
+
+class QuizPage extends StatelessWidget {
+  const QuizPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Quiz App'),
+      ),
+      body: BlocBuilder<QuizBloc, QuizState>(
+        builder: (context, state) {
+          if (state is QuizInitial) {
+            context.read<QuizBloc>().add(StartQuiz());
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is QuizQuestion) {
+            final question = state.question;
+            return Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Question ${state.currentIndex + 1} / ${state.total}',
+                    style: const TextStyle(fontSize: 18),
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    question.text,
+                    style: const TextStyle(fontSize: 20),
+                  ),
+                  const SizedBox(height: 20),
+                  for (int i = 0; i < question.options.length; i++)
+                    OptionCard(
+                      text: question.options[i],
+                      onTap: () => context.read<QuizBloc>().add(SelectOption(i)),
+                      color: state.answered
+                          ? i == question.answerIndex
+                              ? Colors.green
+                              : i == state.selectedIndex
+                                  ? Colors.red
+                                  : null
+                          : null,
+                    ),
+                  const SizedBox(height: 20),
+                  if (state.answered)
+                    ElevatedButton(
+                      onPressed: () => context.read<QuizBloc>().add(NextQuestion()),
+                      child: Text(
+                        state.currentIndex == state.total - 1 ? 'Finish' : 'Next',
+                      ),
+                    ),
+                ],
+              ),
+            );
+          } else if (state is QuizFinished) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Your score: ${state.score} / ${state.total}',
+                    style: const TextStyle(fontSize: 24),
+                  ),
+                  const SizedBox(height: 20),
+                  ElevatedButton(
+                    onPressed: () => context.read<QuizBloc>().add(RestartQuiz()),
+                    child: const Text('Restart Quiz'),
+                  ),
+                ],
+              ),
+            );
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}

--- a/lib/quiz/presentation/widgets/option_card.dart
+++ b/lib/quiz/presentation/widgets/option_card.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class OptionCard extends StatelessWidget {
+  final String text;
+  final VoidCallback onTap;
+  final Color? color;
+
+  const OptionCard({
+    super.key,
+    required this.text,
+    required this.onTap,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: color,
+      child: ListTile(
+        title: Text(text),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_bloc: ^8.1.3
+  equatable: ^2.0.5
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- implement domain layer with `Question` entity, repository interface and a use case
- create a repository implementation returning quiz questions
- add BLoC (events, states, bloc) and UI page using the bloc
- wire bloc into `main.dart`
- add flutter_bloc and equatable dependencies

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884865dc87c832b9241170c8b9f1667